### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is an example app, written in next.js, to show an in-app notification experience, powered by [Knock](https://knock.app).
 
-- [Try out this example](https://https://knock-in-app-notifications-react.vercel.app)
+- [Try out this example](https://knock-in-app-notifications-react.vercel.app)
 - [Read documentation on in-app UI in Knock](https://docs.knock.app/in-app-ui/overview)
 - [Get started with Knock](https://docs.knock.app/getting-started/quick-start)
 


### PR DESCRIPTION
Typo fix in URL. There was a duplicate `https` in the link to the demo web-app.