### PR TITLE
chore: add telegraph packaging grouping for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       include: "scope"
     versioning-strategy: increase
     open-pull-requests-limit: 5
+    groups:
+      telegraph-packages:
+        patterns:
+          - "@telegraph/*"


### PR DESCRIPTION
Version for telegraph aren't getting grouped into one dependabot PR. This fixes that.