### PR TITLE
feat: set up minimum package age 7 days for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@knocklabs/*"
+        - "@telegraph/*"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary
- Adds a 7-day `cooldown` to the npm dependabot config, mirroring [knocklabs/control#8356](https://github.com/knocklabs/control/pull/8356).
- Excludes `@knocklabs/*` and `@telegraph/*` so internal packages keep flowing through without delay.
- Reference: [GitHub docs — setting up a cooldown period for dependency updates](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates).

